### PR TITLE
Add iOS event wizard prototype

### DIFF
--- a/ios-app/.gitignore
+++ b/ios-app/.gitignore
@@ -1,0 +1,3 @@
+# Xcode build artifacts
+build/
+DerivedData/

--- a/ios-app/Models/Event.swift
+++ b/ios-app/Models/Event.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Event {
+struct Event: Codable {
     var name: String = ""
     var description: String = ""
     var selectedDate: Date?
@@ -8,8 +8,8 @@ struct Event {
     var payments: [Payment] = []
 }
 
-struct Payment: Identifiable {
-    let id = UUID()
+struct Payment: Identifiable, Codable {
+    let id: UUID = UUID()
     var participant: String
     var paid: Bool
 }

--- a/ios-app/Models/Event.swift
+++ b/ios-app/Models/Event.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Event {
+    var name: String = ""
+    var description: String = ""
+    var selectedDate: Date?
+    var proposedDates: [Date] = []
+    var payments: [Payment] = []
+}
+
+struct Payment: Identifiable {
+    let id = UUID()
+    var participant: String
+    var paid: Bool
+}

--- a/ios-app/Models/Todo.swift
+++ b/ios-app/Models/Todo.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Todo: Identifiable, Decodable {
+  var id: Int
+  var title: String
+}
+

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,0 +1,16 @@
+# Tribu Event Manager for iOS
+
+Questo è un semplice progetto di esempio scritto in **SwiftUI** che dimostra un wizard per la creazione di nuovi eventi.
+
+Per provarlo:
+
+1. Apri la cartella `ios-app` in Xcode (15 o superiore).
+2. Esegui l'app su un simulatore iOS.
+
+Il wizard guida l'utente attraverso i seguenti passaggi:
+
+1. Inserimento del nome e della descrizione dell'evento.
+2. Scelta di una data esistente oppure creazione di una campagna di votazione per decidere la data.
+3. Gestione dei pagamenti dei partecipanti.
+
+Il codice è un prototipo semplificato e può essere esteso con logica più avanzata per votazioni, sincronizzazione remota e pagamenti.

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -14,3 +14,18 @@ Il wizard guida l'utente attraverso i seguenti passaggi:
 3. Gestione dei pagamenti dei partecipanti.
 
 Il codice è un prototipo semplificato e può essere esteso con logica più avanzata per votazioni, sincronizzazione remota e pagamenti.
+
+## Aspetto minimale
+
+L'interfaccia utilizza i componenti standard di SwiftUI (`NavigationView`, `Form`, `Toggle`) mantenendo un look essenziale.
+Puoi personalizzare colori o font applicando i modifier di SwiftUI per restare fedele a questa semplicità.
+
+## Integrazione Supabase
+
+Aggiungi il package `supabase-swift` tramite Swift Package Manager usando:
+
+```
+https://github.com/supabase/supabase-swift
+```
+
+Le credenziali di esempio si trovano nel file `Supabase.swift` e permettono di salvare gli eventi nella tabella `events` e di recuperare i `todos` mostrati in `ContentView.swift`.

--- a/ios-app/Supabase.swift
+++ b/ios-app/Supabase.swift
@@ -1,0 +1,8 @@
+import Foundation
+import Supabase
+
+let supabase = SupabaseClient(
+  supabaseURL: URL(string: "https://oweozyztubzewzonfkuu.supabase.co")!,
+  supabaseKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im93ZW96eXp0dWJ6ZXd6b25ma3V1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg5ODE1NTAsImV4cCI6MjA2NDU1NzU1MH0.Ulo9bGcBYX1FX-SX7YYHuV8ezVS1hCDgqNr9V60nQA4"
+)
+

--- a/ios-app/TribuEventManagerApp.swift
+++ b/ios-app/TribuEventManagerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct TribuEventManagerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            EventWizardView()
+        }
+    }
+}

--- a/ios-app/Views/ContentView.swift
+++ b/ios-app/Views/ContentView.swift
@@ -1,0 +1,27 @@
+import Supabase
+import SwiftUI
+
+struct ContentView: View {
+  @State var todos: [Todo] = []
+
+  var body: some View {
+    NavigationStack {
+      List(todos) { todo in
+        Text(todo.title)
+      }
+      .navigationTitle("Todos")
+      .task {
+        do {
+          todos = try await supabase.from("todos").select().execute().value
+        } catch {
+          debugPrint(error)
+        }
+      }
+    }
+  }
+}
+
+#Preview {
+  ContentView()
+}
+

--- a/ios-app/Views/EventWizardView.swift
+++ b/ios-app/Views/EventWizardView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Supabase
 
 struct EventWizardView: View {
     @State private var step: Int = 1
@@ -15,6 +16,8 @@ struct EventWizardView: View {
                     StepTwo
                 } else {
                     StepThree
+                    Button("Salva") { saveEvent() }
+                        .padding(.top)
                 }
                 Spacer()
                 HStack {
@@ -81,6 +84,16 @@ struct EventWizardView: View {
                         Toggle(payment.participant, isOn: $payment.paid)
                     }
                 }
+            }
+        }
+    }
+
+    private func saveEvent() {
+        Task {
+            do {
+                _ = try await supabase.from("events").insert(event).execute()
+            } catch {
+                debugPrint(error)
             }
         }
     }

--- a/ios-app/Views/EventWizardView.swift
+++ b/ios-app/Views/EventWizardView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct EventWizardView: View {
+    @State private var step: Int = 1
+    @State private var event = Event()
+    @State private var newProposedDate = Date()
+    @State private var newParticipant = ""
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if step == 1 {
+                    StepOne
+                } else if step == 2 {
+                    StepTwo
+                } else {
+                    StepThree
+                }
+                Spacer()
+                HStack {
+                    if step > 1 { Button("Indietro") { step -= 1 } }
+                    Spacer()
+                    if step < 3 { Button("Avanti") { step += 1 } }
+                }
+                .padding()
+            }
+            .navigationTitle("Nuovo Evento")
+        }
+    }
+
+    var StepOne: some View {
+        Form {
+            TextField("Nome", text: $event.name)
+            TextField("Descrizione", text: $event.description)
+        }
+    }
+
+    var StepTwo: some View {
+        Form {
+            Toggle("Seleziona data esistente", isOn: Binding(
+                get: { event.selectedDate != nil },
+                set: { useExisting in
+                    if useExisting {
+                        event.proposedDates.removeAll()
+                    } else {
+                        event.selectedDate = nil
+                    }
+                }))
+            if event.selectedDate != nil {
+                DatePicker("Data evento", selection: Binding(
+                    get: { event.selectedDate ?? Date() },
+                    set: { event.selectedDate = $0 }
+                ), displayedComponents: .date)
+            } else {
+                DatePicker("Proponi una data", selection: $newProposedDate, displayedComponents: .date)
+                Button("Aggiungi data") {
+                    event.proposedDates.append(newProposedDate)
+                }
+                if !event.proposedDates.isEmpty {
+                    Text("Date proposte:")
+                    ForEach(event.proposedDates, id: \.self) { date in
+                        Text(date, style: .date)
+                    }
+                }
+            }
+        }
+    }
+
+    var StepThree: some View {
+        Form {
+            HStack {
+                TextField("Partecipante", text: $newParticipant)
+                Button("Aggiungi") {
+                    event.payments.append(Payment(participant: newParticipant, paid: false))
+                    newParticipant = ""
+                }
+            }
+            if !event.payments.isEmpty {
+                Section(header: Text("Pagamenti")) {
+                    ForEach($event.payments) { $payment in
+                        Toggle(payment.participant, isOn: $payment.paid)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct EventWizardView_Previews: PreviewProvider {
+    static var previews: some View {
+        EventWizardView()
+    }
+}


### PR DESCRIPTION
## Summary
- add README instructions for iOS prototype
- add SwiftUI entry point for the app
- define Event and Payment models
- implement a basic wizard view with SwiftUI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5819a0c0832595393eec675e8c31